### PR TITLE
Return existing writeup as reason not to publish in given E2NODE. (Re…

### DIFF
--- a/ecore/Everything/Delegation/htmlcode.pm
+++ b/ecore/Everything/Delegation/htmlcode.pm
@@ -14089,7 +14089,7 @@ sub nopublishreason
   foreach (@group)
   {
     getRef($_);
-    return if $$_{author_user} == $$user{node_id};
+    return $_ if $$_{author_user} == $$user{node_id};
   }
 
   # no more checks if author has an editor-approved a draft for this node:


### PR DESCRIPTION
…pair of regression in delegation)