### PR TITLE
Replace http with https

### DIFF
--- a/ecore/Everything/Delegation/htmlcode.pm
+++ b/ecore/Everything/Delegation/htmlcode.pm
@@ -7631,7 +7631,7 @@ sub displayWriteupInfo
     return ''
       . '<button title="Add additional World Cup content"'
       . ' onClick="flatify(this);return false;">'
-      . '<img src="http://static.everything2.com/futbol.png">'
+      . '<img src="https://s3.amazonaws.com/static.everything2.com/futbol.png">'
       . '</button>';
   };
 
@@ -13176,7 +13176,7 @@ sub homenodeinfectedinfo
     $infectionLink = linkNode($infectionExplanation, $infectionLink);
     $infectedHTML .= qq|;
       <div>
-      <img src="http://static.everything2.com/biohazard.png" alt="Biohazard Sign" title="User is infected">
+      <img src="https://s3.amazonaws.com/static.everything2.com/biohazard.png" alt="Biohazard Sign" title="User is infected">
       <p>
       This user is $infectionLink.
       </p>
@@ -13191,7 +13191,7 @@ sub homenodeinfectedinfo
         . $query->hidden("confirmop", 'cure_infection')
         . $query->hidden("cure_user_id", $$NODE{node_id})
         . '<button class="ajax homenode_infection:homenodeinfectedinfo?op=cure_infection&cure_user_id=/&cure_infection_seed=/&cure_infection_nonce=/&confirmmsg=/#Are+you+sure+you+wish+to+cure+this+user&apos;s+infection">
-          <img src="http://static.everything2.com/physician.png" alt="Physician Sign">
+          <img src="https://s3.amazonaws.com/static.everything2.com/physician.png" alt="Physician Sign">
            <p>Cure User</p> </button>'
         . '</form>'
         . "</div>\n";
@@ -14125,7 +14125,7 @@ sub showpoll
       $str.='<tr><td>'.($i == $vote ? '<b>' : '').$options[$i].($i ==$vote ? '</b>' : '').'</td>
         <td align="right">&nbsp;'.$results[$i].'&nbsp;</td>
         <td align="right">'.sprintf("%2.2f",($results[$i]/$votedivider)*100).'%</td></tr>';
-      $str.="<tr><td colspan='3'><img class='oddrow' src='http://static.everything2.com/dot.gif' height='8' width='"
+      $str.="<tr><td colspan='3'><img class='oddrow' src='https://s3.amazonaws.com/static.everything2.com/dot.gif' height='8' width='"
         .sprintf("%2.0f",($results[$i]/$votedivider)*180)."' /></td></tr>";
       $i++;
     }

--- a/nodepack/superdoc/e2_full_text_search.xml
+++ b/nodepack/superdoc/e2_full_text_search.xml
@@ -1,7 +1,7 @@
 <node>
   <type_nodetype>14</type_nodetype>
   <doctext>&lt;script type=&quot;text/javascript&quot;&gt;
-	$('head').append('&lt;link rel=&quot;stylesheet&quot; type=&quot;text/css&quot; href=&quot;http://www.google.com/cse/api/branding.css&quot;&gt;');
+	$('head').append('&lt;link rel=&quot;stylesheet&quot; type=&quot;text/css&quot; href=&quot;https://www.google.com/cse/api/branding.css&quot;&gt;');
 &lt;/script&gt;
 &lt;div class=&quot;cse-branding-right&quot; style=&quot;background-color:#FFFFFF;color:#000000&quot;&gt;
   &lt;div class=&quot;cse-branding-form&quot;&gt;
@@ -17,7 +17,7 @@
     &lt;/form&gt;
   &lt;/div&gt;
   &lt;div class=&quot;cse-branding-logo&quot;&gt;
-    &lt;img src=&quot;http://www.google.com/images/poweredby_transparent/poweredby_FFFFFF.gif&quot; alt=&quot;Google&quot;&gt;
+    &lt;img src=&quot;https://www.google.com/images/poweredby_transparent/poweredby_FFFFFF.gif&quot; alt=&quot;Google&quot;&gt;
   &lt;/div&gt;
   &lt;div class=&quot;cse-branding-text&quot;&gt;
     Custom Search
@@ -36,7 +36,7 @@
   var googleSearchDomain = &quot;www.google.com&quot;;
   var googleSearchPath = &quot;/cse&quot;;
 &lt;/script&gt;
-&lt;script type=&quot;text/javascript&quot; src=&quot;http://www.google.com/afsonline/show_afs_search.js&quot;&gt;&lt;/script&gt;
+&lt;script type=&quot;text/javascript&quot; src=&quot;https://www.google.com/afsonline/show_afs_search.js&quot;&gt;&lt;/script&gt;
 
 &lt;!-- Google Search Result Snippet Ends --&gt;
 </doctext>


### PR DESCRIPTION
This fixes "mixed content" error messages in the browser. An https site can load certain http content without too many complaints, but browsers typically won't load insecure scripts without a user prompt.

I don't know if these nodepacks are being used yet, so I also submitted a patch directly on E2. See [Patch Manager]