### PR TITLE
Everything::Request generates $PAGELOAD

### DIFF
--- a/ecore/Everything/API.pm
+++ b/ecore/Everything/API.pm
@@ -102,7 +102,7 @@ sub _build_routechooser
 
 sub routes
 {
-  {"/" => "get"}
+  return {"/" => "get"}
 }
 
 sub get

--- a/ecore/Everything/APIRouter.pm
+++ b/ecore/Everything/APIRouter.pm
@@ -31,14 +31,14 @@ sub dispatcher
   {
     if(exists $self->CONTROLLER_TABLE->{$endpoint})
     {
-      $self->output($REQUEST, $self->CONTROLLER_TABLE->{$endpoint}->route($REQUEST, $extra));
+      return $self->output($REQUEST, $self->CONTROLLER_TABLE->{$endpoint}->route($REQUEST, $extra));
     }else{
       $self->devLog("Request fell through to catchall after CONTROLLER_TABLE check");
-      $self->output($REQUEST, $self->CONTROLLER_TABLE->{catchall}->$method($REQUEST));
+      return $self->output($REQUEST, $self->CONTROLLER_TABLE->{catchall}->$method($REQUEST));
     }
   }else{
     $self->devLog("Request fell through to catchall after form check: $method for $urlform");
-    $self->output($REQUEST, $self->CONTROLLER_TABLE->{catchall}->$method($REQUEST));
+    return $self->output($REQUEST, $self->CONTROLLER_TABLE->{catchall}->$method($REQUEST));
   }
 }
 

--- a/ecore/Everything/CacheQueue.pm
+++ b/ecore/Everything/CacheQueue.pm
@@ -203,7 +203,7 @@ sub removeItem
 {
 	my ($this, $data) = @_;
 
-	return undef if(not defined $data);
+	return if(not defined $data);
 
 	$this->removeData($data);
 	return $$data{item};

--- a/ecore/Everything/Configuration.pm
+++ b/ecore/Everything/Configuration.pm
@@ -89,7 +89,7 @@ around BUILDARGS => sub
   if(@_ == 0)
   {
     $configfile = '/etc/everything/everything.conf.json';
-  }elsif(@_ == 1 and !ref $_[0])
+  }elsif((@_ == 1) and (!(ref $_[0])))
   {
     # If there is one arg, assume it is the configfile
     $configfile = $_[0];

--- a/ecore/Everything/FormMenu.pm
+++ b/ecore/Everything/FormMenu.pm
@@ -9,6 +9,7 @@ package Everything::FormMenu;
 #############################################################################
 
 use strict;
+use warnings;
 use Everything;
 use Everything::HTML;
 

--- a/ecore/Everything/HTML.pm
+++ b/ecore/Everything/HTML.pm
@@ -1377,6 +1377,7 @@ sub mod_perlInit
 
 	$USER = $REQUEST->USER;
         $VARS = $REQUEST->VARS;
+	$PAGELOAD = $REQUEST->PAGELOAD;
 
          #only for Everything2.com
          if ($query->param("op") eq "randomnode") {

--- a/ecore/Everything/Node/helper/delegated.pm
+++ b/ecore/Everything/Node/helper/delegated.pm
@@ -11,7 +11,7 @@ sub code_text
   my $filedata = undef;
   my $fileh = undef;
 
-  open $fileh,$file;
+  open($fileh,'<',$file);
   {
     local $/ = undef;
     $filedata = <$fileh>;

--- a/ecore/Everything/Request.pm
+++ b/ecore/Everything/Request.pm
@@ -14,7 +14,7 @@ has 'VARS' => (lazy => 1, builder => "_build_vars", isa => "HashRef", is => "rw"
 has 'user' => (lazy => 1, builder => "_build_blessed_user", isa => "Everything::Node::user", is => "rw", handles => ["is_guest","is_admin","is_developer","is_chanop","is_clientdev","is_editor"]);
 
 # Pageload is going to go away
-has 'PAGELOAD' => (isa => "HashRef", builder => "_build_pageload", is => "rw");
+has 'PAGELOAD' => (isa => "HashRef", default => sub { {} }, is => "rw");
 
 has 'NODE' => (is => "rw", isa => "HashRef");
 
@@ -58,12 +58,6 @@ sub _build_blessed_user
   my $self = shift;
 
   return $self->APP->node_by_id($self->USER->{node_id});
-}
-
-sub _build_pageload
-{
-  my $self = shift;
-  return {};
 }
 
 sub _build_vars

--- a/ecore/Everything/Router.pm
+++ b/ecore/Everything/Router.pm
@@ -59,6 +59,8 @@ sub output
       print $data;
     }
   }
+
+  return;
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/ecore/Everything/dataprovider/links.pm
+++ b/ecore/Everything/dataprovider/links.pm
@@ -1,10 +1,10 @@
-#!/usr/bin/perl -w
-
-use strict;
-use lib qw(lib);
-use Everything::dataprovider::base;
 package Everything::dataprovider::links;
 use base qw(Everything::dataprovider::base);
+
+
+use strict;
+use warnings
+use lib qw(lib);
 
 sub data_out
 {
@@ -31,6 +31,7 @@ sub data_in
 	{
 		$this->_hash_insert("links",$link);
 	}
+	return;
 }
 
 1;

--- a/ecore/Everything/dataprovider/nodeparam.pm
+++ b/ecore/Everything/dataprovider/nodeparam.pm
@@ -1,10 +1,8 @@
-#!/usr/bin/perl -w
+package Everything::dataprovider::nodeparam;
+use base qw(Everything::dataprovider::base);
 
 use strict;
 use lib qw(lib);
-use Everything::dataprovider::base;
-package Everything::dataprovider::nodeparam;
-use base qw(Everything::dataprovider::base);
 
 sub data_out
 {


### PR DESCRIPTION
Inside of Everything::HTML, the initial reference for pageload comes from within the Everything::Request object so that it can be carried as a part of the global for the logic encapsulation push

Also a small round of perlcritic fixes

Fixes #533