### PR TITLE
Fixes perlcritic warnings in Everything::Memcache

### DIFF
--- a/ecore/Everything/Memcache.pm
+++ b/ecore/Everything/Memcache.pm
@@ -15,8 +15,11 @@ package Everything::Memcache;
 #############################################################################
 
 use strict;
+use warnings;
 use Everything;
 use Cache::Memcached;
+
+## no critic (ProhibitAutomaticExportation)
 
 sub BEGIN
 {


### PR DESCRIPTION
We're silencing the export warnings for now

Fixes #863