### PR TITLE
Robuster polls

### DIFF
--- a/ecore/Everything/Delegation/opcode.pm
+++ b/ecore/Everything/Delegation/opcode.pm
@@ -2005,7 +2005,7 @@ sub pollvote
     && exists($result_array[$vote]);
 
   return if $DB->sqlSelect( # has already voted on this poll
-    'vote_id'
+    'pollvote_id'
     , 'pollvote'
     , "voter_user=$$USER{node_id} AND pollvote_id=$$N{node_id}");
 

--- a/ecore/Everything/Delegation/opcode.pm
+++ b/ecore/Everything/Delegation/opcode.pm
@@ -2000,9 +2000,10 @@ sub pollvote
   my $vote = $query->param('vote');
 
   my $N = getNodeById($pollId);
+  my @options = split /\n\s*/s, $$N{doctext};
   my @result_array = split(',', $$N{e2poll_results});
   return unless $N  && $$N{type}{title} eq 'e2poll' && $$N{poll_status} ne 'new' && $$N{poll_status} ne 'closed'
-    && exists($result_array[$vote]);
+    && exists($options[$vote]);
 
   return if $DB->sqlSelect( # has already voted on this poll
     'pollvote_id'


### PR DESCRIPTION
The last poll broke because the e2poll_results field only contained a list of votes for four options while the poll had more than that. This can happen if a poll is edited after being created. Rather than create an update maintenance, this extends the list in e2poll_results on the fly as appropriate.