### PR TITLE
Eliminate old SSL mutex invocation that isn't needed

### DIFF
--- a/vagrant/cookbooks/e2database/recipes/default.rb
+++ b/vagrant/cookbooks/e2database/recipes/default.rb
@@ -41,9 +41,11 @@ execute "mysql permissions" do
   creates "/etc/chef_setup/mysql_permissions"
 end
 
+db_bootstrap = '/etc/chef_setup/database_bootstrap'
+
 execute "database bootstrap" do
-  command "/var/everything/tools/qareload.pl"
-  creates "/etc/chef_setup/database_bootstrap"
+  command "/var/everything/tools/qareload.pl && touch #{db_bootstrap}"
+  creates "#{db_bootstrap}"
 end
 
 service "mysql" do

--- a/vagrant/cookbooks/e2web/recipes/default.rb
+++ b/vagrant/cookbooks/e2web/recipes/default.rb
@@ -102,27 +102,12 @@ end
 logdir = "/var/log/everything"
 datelog = "`date +\\%Y\\%m\\%d\\%H`.log"
 
-directory "/var/run/apache2/ssl_mutex" do
-  owner "www-data"
-  group "root"
-  mode 0755
-  action :create
-  notifies :restart, "service[apache2]", :delayed
-end
-
 directory logdir do
   owner "www-data"
   group "root"
   mode 0755
   action :create
   notifies :restart, "service[apache2]", :delayed
-end
-
-directory '/var/run/apache2/ssl_mutex' do
-  owner "www-data"
-  group "root"
-  mode 0755
-  action :create
 end
 
 cron 'log_deliver_to_s3.pl' do

--- a/vagrant/cookbooks/e2web/templates/default/apache2.conf.erb
+++ b/vagrant/cookbooks/e2web/templates/default/apache2.conf.erb
@@ -1,8 +1,4 @@
-<% if node['platform'].eql? 'ubuntu' %>
 Mutex file:${APACHE_LOCK_DIR} default
-<% else %> 
-LockFile ${APACHE_LOCK_DIR}/accept.lock
-<% end %>
 PidFile ${APACHE_PID_FILE}
 
 Timeout 300
@@ -45,10 +41,6 @@ LogFormat "%{User-agent}i" agent
 ##### E2 CUSTOM SETTINGS #####
 UseCanonicalName On
 
-<% unless node['platform'].eql? 'ubuntu' %>
-# DEFAULT RETURN TYPE IF NOT SPECIFIED OR INTERPRETED
-DefaultType text/plain
-<% end %>
 # DON'T RDNS LOOK UP HOST IPS FOR BEST SPEED
 HostnameLookups Off
 # SPECIFY, ENABLE AND PROTECT .htaccess FILES

--- a/vagrant/cookbooks/e2web/templates/default/everything.erb
+++ b/vagrant/cookbooks/e2web/templates/default/everything.erb
@@ -60,10 +60,7 @@ node["banned_user_agents"].each do |ua|
 	coreconfig+="\tBrowserMatchNoCase #{ua} denyip\n"
 end
 
-rotatelogs = '/usr/sbin/rotatelogs'
-if node['platform'].eql? 'ubuntu'
-  rotatelogs = '/usr/bin/rotatelogs'
-end
+rotatelogs = '/usr/bin/rotatelogs'
 
 coreconfig+="
 	<Directory /var/everything/www/>
@@ -111,9 +108,6 @@ coreconfig+="
 %>
 PerlSwitches -I/var/everything/ecore
 ServerName everything2.com
-<% unless node['platform'].eql? 'ubuntu' %>
-NameVirtualHost *:80
-<% end %>
 <VirtualHost *:80>
 <%=coreconfig %>
 </VirtualHost>

--- a/vagrant/cookbooks/e2web/templates/default/ssl.conf.erb
+++ b/vagrant/cookbooks/e2web/templates/default/ssl.conf.erb
@@ -43,16 +43,6 @@ SSLPassPhraseDialog  builtin
 SSLSessionCache        shmcb:${APACHE_RUN_DIR}/ssl_scache(512000)
 SSLSessionCacheTimeout  300
 
-#   Semaphore:
-#   Configure the path to the mutual exclusion semaphore the
-#   SSL engine uses internally for inter-process synchronization. 
-
-<% if node['platform'].eql? 'ubuntu' %>
-Mutex file:${APACHE_RUN_DIR}/ssl_mutex
-<% else %>
-SSLMutex  file:${APACHE_RUN_DIR}/ssl_mutex
-<% end %>
-
 #   SSL Cipher Suite:
 #   List the ciphers that the client is permitted to negotiate. See the
 #   ciphers(1) man page from the openssl package for list of all available


### PR DESCRIPTION
Actually create the file for database bootstrapping when we bootstrap qa

Remove old ubuntu checks

Fixes #1393