### PR TITLE
In development, the development.log file lives in tmp

### DIFF
--- a/vagrant/cookbooks/e2web/recipes/default.rb
+++ b/vagrant/cookbooks/e2web/recipes/default.rb
@@ -115,6 +115,24 @@ cron 'log_deliver_to_s3.pl' do
   command "/var/everything/tools/log_deliver_to_s3.pl 2>&1 >> #{logdir}/e2cron.log_deliver_to_s3.#{datelog}"
 end
 
+unless node['e2engine']['environment'].eql? 'production'
+  template "/lib/systemd/system/apache2.service" do
+    owner "root"
+    group "root"
+    mode "0755"
+    action "create"
+    source 'apache2.service.erb'
+    notifies :restart, "service[apache2]", :delayed
+  end
+
+  bash "systemctl reload" do
+    cwd "/tmp"
+    user "root"
+    code "systemctl daemon-reload"
+  end
+end
+
+
 service 'apache2' do
   supports :status => true, :restart => true, :reload => true, :stop => true
 end

--- a/vagrant/cookbooks/e2web/templates/default/apache2.service.erb
+++ b/vagrant/cookbooks/e2web/templates/default/apache2.service.erb
@@ -1,0 +1,15 @@
+[Unit]
+Description=The Apache HTTP Server
+After=network.target remote-fs.target nss-lookup.target
+
+[Service]
+Type=forking
+Environment=APACHE_STARTED_BY_SYSTEMD=true
+ExecStart=/usr/sbin/apachectl start
+ExecStop=/usr/sbin/apachectl stop
+ExecReload=/usr/sbin/apachectl graceful
+PrivateTmp=true
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Newer versions of apache have a privatetmp in their systemd config;

This sets PrivateTmp to false in development

Fixes #1382