### PR TITLE
Removes the redefined Mason filter

### DIFF
--- a/ecore/Mason/Plugin/Everything/Filters.pm
+++ b/ecore/Mason/Plugin/Everything/Filters.pm
@@ -12,10 +12,4 @@ method ParseLinks ($lastnode) {
   }
 }
 
-method ParseLinks {
-  return sub {
-    $Everything::APP->parseLinks(@_);
-  }
-}
-
 1;


### PR DESCRIPTION
Cleans up code so warnings are less noisy
Fixes #1498