### PR TITLE
Increase the amount of RAM in the Vagrantbox for serverless testing

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
   config.vm.provider :virtualbox do |vb|
     vb.name = "Everything2 Development Environment"
     vb.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]  
-    vb.customize ["modifyvm", :id, "--memory", 1024]
+    vb.customize ["modifyvm", :id, "--memory", 2048]
   end
 
   config.vm.provision :chef_solo do |chef|


### PR DESCRIPTION
Fixes #2140