### PR TITLE
This checkin does a lot of things:

### DIFF
--- a/docker/e2db/Dockerfile
+++ b/docker/e2db/Dockerfile
@@ -1,6 +1,6 @@
 FROM everything2/e2app
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install mysql-server -y
-RUN mkdir /var/run/mysqld 
+RUN mkdir -p /var/run/mysqld 
 RUN chown mysql:mysql /var/run/mysqld
 COPY docker/e2db/mysqld_dev_wrapper.sh /var/everything
 RUN chmod +x /var/everything/mysqld_dev_wrapper.sh

--- a/ecore/Everything/Application.pm
+++ b/ecore/Everything/Application.pm
@@ -3465,8 +3465,6 @@ sub linkNodeTitle {
 
 sub canCompress
 {
-  #TODO: Check to see if we can do this as an apache module, safely
-  #TODO: Don't compress things of shorter than X bytes
   #TODO: Support deflate?
   if($ENV{HTTP_ACCEPT_ENCODING} and $ENV{HTTP_ACCEPT_ENCODING} =~ /gzip/)
   {
@@ -3640,19 +3638,19 @@ sub stylesheetCDNLink
 
   $this->{db}->getRef($stylesheet);
 
-  if($Everything::CONF->use_local_css)
+  if($Everything::CONF->use_local_assets)
   {
     return "/css/$$stylesheet{node_id}.css";
   }
   
   my $filename = "$$stylesheet{node_id}.min";
-  if($ENV{HTTP_ACCEPT_ENCODING} and $ENV{HTTP_ACCEPT_ENCODING} =~ /gzip/)
+  if($this->canCompress)
   {
     $filename.= ".gz";
   }
   
   $filename .= ".css";
-  return "https://s3-us-west-2.amazonaws.com/deployed.everything2.com/".$this->{conf}->last_commit."/$filename";
+  return $Everything::CONF->assets_location."/$filename";
 }
 
 sub pagetitle

--- a/ecore/Everything/Controller.pm
+++ b/ecore/Everything/Controller.pm
@@ -68,6 +68,14 @@ sub layout
   $e2->{lastnode_id} = $params->{lastnode_id};
   $e2->{title} = $node->title;
   $e2->{guest} = $REQUEST->is_guest;
+  $e2->{use_local_assets} = $self->CONF->use_local_assets;
+  if($e2->{use_local_assets} == 0)
+  {
+    $e2->{assets_location} = $self->CONF->assets_location;
+  }else{
+    $e2->{assets_location} = "";
+  }
+  $e2->{can_gzip} = $REQUEST->can_gzip;
 
   my $cookie = undef;
   foreach ('fxDuration', 'collapsedNodelets', 'settings_useTinyMCE', 'autoChat', 'inactiveWindowMarker'){

--- a/ecore/Everything/Delegation/nodelet.pm
+++ b/ecore/Everything/Delegation/nodelet.pm
@@ -459,6 +459,7 @@ sub recommended_reading
   $str.='<h4>'.linkNode(getNode('Cool Archive','superdoc'), 'User Picks').'</h4>';
   $str.='<ul class="infolist">';
   my $coolnodes = $DB->stashData("coolnodes");
+  $coolnodes = [] unless(defined($coolnodes) and UNIVERSAL::isa($coolnodes,"ARRAY")); 
   my $count = 0;
   my $seen = {};
 
@@ -476,6 +477,7 @@ sub recommended_reading
   $str.='</ul>';
 
   my $staffpicks = $DB->stashData("staffpicks");
+  $staffpicks = [] unless(defined($staffpicks) and UNIVERSAL::isa($staffpicks,"ARRAY"));
 
   # From [rtnsection_edc]
   $str.= '<h4>'.linkNode(getNode('Page of Cool','superdoc'), 'Editor Picks').'</h4>';

--- a/ecore/Everything/Node/helper/s3.pm
+++ b/ecore/Everything/Node/helper/s3.pm
@@ -2,24 +2,16 @@ package Everything::Node::helper::s3;
 
 use Moose::Role;
 
-sub use_local
-{
-  my ($self) = @_;
-
-  my $attr = $self->local_pref;
-  return $self->CONF->$attr;
-}
-
 sub cdn_link
 {
   my ($self, $decoration) = @_;
 
-  if($self->use_local)
+  if($self->CONF->use_local_assets)
   {
     return "/".$self->media_extension."/".$self->node_id.'.'.$self->media_extension;
   }
 
-  my $link = "https://s3-us-west-2.amazonaws.com/deployed.everything2.com/".$self->CONF->last_commit."/";
+  my $link = $self->CONF->assets_location;
   $link .= join(".",$self->node_id,"min");
   $link .= ".$decoration" if $decoration;
   $link .= ".".$self->media_extension;

--- a/ecore/Everything/Node/jscript.pm
+++ b/ecore/Everything/Node/jscript.pm
@@ -4,7 +4,6 @@ extends 'Everything::Node';
 
 with 'Everything::Node::helper::s3';
 has 'media_extension' => (isa => 'Str', is => 'ro', default => 'js');
-has 'local_pref' => (isa => 'Str', is => 'ro', default => 'use_local_javascript');
 
 __PACKAGE__->meta->make_immutable;
 1;

--- a/ecore/Everything/Node/stylesheet.pm
+++ b/ecore/Everything/Node/stylesheet.pm
@@ -5,7 +5,6 @@ extends 'Everything::Node';
 with 'Everything::Node::helper::s3';
 
 has 'media_extension' => (isa => 'Str', is => 'ro', default => 'css');
-has 'local_pref' => (isa => 'Str', is => 'ro', default => 'use_local_css');
 
 sub supported
 {

--- a/etc/development-docker.json
+++ b/etc/development-docker.json
@@ -1,8 +1,7 @@
 {
   "everything_dbserv": "e2devdb",
   "canonical_web_server": "development.everything2.com",
-  "use_local_javascript": 1,
-  "use_local_css": 1,
+  "use_local_assets": 1,
   "google_ads_badnodes": [
     "123456"
   ]

--- a/etc/development.json
+++ b/etc/development.json
@@ -1,8 +1,7 @@
 {
   "everything_dbserv": "localhost",
   "canonical_web_server": "development.everything2.com",
-  "use_local_javascript": 1,
-  "use_local_css": 1,
+  "use_local_assets": 1,
   "google_ads_badnodes": [
     "123456"
   ]

--- a/etc/docker-mysql-development.json
+++ b/etc/docker-mysql-development.json
@@ -2,7 +2,7 @@
   "everything_dbserv": "127.0.0.1",
   "everything_dbport": 3306,
   "canonical_web_server": "development.everything2.com",
-  "use_local_javascript": 1,
+  "use_local_assets": 1,
   "google_ads_badnodes": [
     "123456"
   ]

--- a/tools/conftest.pl
+++ b/tools/conftest.pl
@@ -8,7 +8,7 @@ use Everything;
 initEverything 'everything';
 
 
-foreach my $item (qw(configfile configdir site_url guest_user infected_ips default_style everyuser everypass everything_dbserv database cookiepass canonical_web_server homenode_image_host mail_from nodecache_size environment s3 static_nodetypes clean_search_words_aggressively search_row_limit logdirectory use_local_javascript site_name create_new_user default_guest_node maintenance_nodes permanent_cache nosearch_words recaptcha_v3_public_key google_ads_badwords google_ads_badnodes))
+foreach my $item (qw(configfile configdir site_url guest_user infected_ips default_style everyuser everypass everything_dbserv database cookiepass canonical_web_server homenode_image_host mail_from nodecache_size environment s3 static_nodetypes clean_search_words_aggressively search_row_limit logdirectory site_name create_new_user default_guest_node maintenance_nodes permanent_cache nosearch_words recaptcha_v3_public_key google_ads_badwords google_ads_badnodes))
 {
   if(UNIVERSAL::isa($Everything::CONF->$item,"ARRAY"))
   {

--- a/tools/qareload.pl
+++ b/tools/qareload.pl
@@ -15,6 +15,6 @@ if($Everything::CONF->environment ne "development")
 `echo "create database everything DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci" | mysql -u root`;
 `/var/everything/ecoretool/ecoretool.pl bootstrap --nodepack=/var/everything/nodepack`;
 `/var/everything/tools/seeds.pl`;
-`/var/everything/tools/data_generator_heartbeat.pl`;
-`/var/everything/tools/data_generator_heartbeat.pl --lengthy`;
+`/var/everything/cron/cron_datastash.pl`;
+`/var/everything/cron/cron_datastash.pl --lengthy`;
 `/etc/init.d/apache2 restart`;

--- a/www/js/1874924.js
+++ b/www/js/1874924.js
@@ -476,7 +476,7 @@ e2 = $.extend( function(x){return e2.shortFunctions[typeof x].apply(this, argume
 			active: {},
 
 			'HTML toolbar': {
-				library: 'https://s3-us-west-2.amazonaws.com/jscssw.everything2.com/2069738.js',
+				library: e2.use_local_assets?('/js/2069738.js'):(e2.can_gzip?(e2.assets_location + "/2069738.min.gz.js"):(e2.assets_location + "/2069738.js")),
 				test: 'edToolbar',
 	
 				stop: function(id){

--- a/www/js/2069738.js
+++ b/www/js/2069738.js
@@ -526,6 +526,34 @@ function literalize(which) {
 	edInsertContent(which,literalizedStr);
 }
 
+function autoFormat (id)
+{
+  var elem = document.getElementsByName(id).item(0);
+  var text = elem.value;
+  var blocks = "pre|center|li|ol|ul|h1|h2|h3|h4|h5|h6" +
+    "|blockquote|dd|dt|dl|p" +
+    "|table|td|tr|th";
+
+  text = '<p>' + text
+    // strip out existing formatting
+    .replace (new RegExp('</?p>', 'ig'), '')
+    .replace (new RegExp('<br */?>', 'ig'), '')
+    // Strip out leading and trailing space
+    .replace (new RegExp('\\s*$', 'ig'), '')
+    .replace (new RegExp('^\\s*', 'ig'), '')
+    // New formatting
+    .replace (new RegExp("\n", 'ig'), "<br />\n")
+    .replace (new RegExp("<br />\n(<br />\n)+", 'ig'), "</p>\n\n<p>")
+    + '</p>';
+  text = text
+    // Fix block elements
+    .replace (new RegExp('<p><('+blocks+'[ >])', 'ig'), '<$1')
+    .replace (new RegExp('</('+blocks+')></p>', 'ig'), '</$1>');
+
+  elem.value = text;
+
+}
+
 function edToolbar(which) {
 	document.write('<div id="ed_toolbar_' + which + '"><span>');
 	for (i = 0; i < extendedStart; i++) {
@@ -534,7 +562,7 @@ function edToolbar(which) {
 	if (edShowExtraCookie()) {
 		document.write(
 			'<input type="button" id="ed_close_' + which + '" class="ed_button" onclick="edCloseAllTags(\'' + which + '\');" value="Close Tags" />'
-			/* + '<input type="button" id="ed_autoformat_' + which + '" class="ed_button" onclick="autoFormat(\'' + which + '\');" value="Line Breaks" title="Insert paragraph and line-break tags based on line breaks in the source" />' */
+			+ '<input type="button" id="ed_autoformat_' + which + '" class="ed_button" onclick="autoFormat(\'' + which + '\');" value="Line Breaks" title="Insert paragraph and line-break tags based on line breaks in the source" />'
 			+ '<input type="button" id="ed_spell_' + which + '" class="ed_button" onclick="edSpell(\'' + which + '\');" value="Dict" />'
 			+ '<input type="button" id="ed_extra_show_' + which + '" class="ed_button" onclick="edShowExtra(\'' + which + '\')" value="&raquo;" style="visibility: hidden;" />'
 			+ '</span><br />'

--- a/www/js/2069739.js
+++ b/www/js/2069739.js
@@ -1,30 +1,3 @@
 // 2067939.js "Autoformat javascript"
 // Unknown usage
 
-function autoFormat (id)
-{
-  var elem = document.getElementsByName(id).item(0);
-  var text = elem.value;
-  var blocks = "pre|center|li|ol|ul|h1|h2|h3|h4|h5|h6" +
-    "|blockquote|dd|dt|dl|p" +
-    "|table|td|tr|th";
-
-  text = '<p>' + text
-    // strip out existing formatting 
-    .replace (new RegExp('</?p>', 'ig'), '')
-    .replace (new RegExp('<br */?>', 'ig'), '')
-    // Strip out leading and trailing space
-    .replace (new RegExp('\\s*$', 'ig'), '')
-    .replace (new RegExp('^\\s*', 'ig'), '')
-    // New formatting
-    .replace (new RegExp("\n", 'ig'), "<br />\n")
-    .replace (new RegExp("<br />\n(<br />\n)+", 'ig'), "</p>\n\n<p>")
-    + '</p>';
-  text = text
-    // Fix block elements
-    .replace (new RegExp('<p><('+blocks+'[ >])', 'ig'), '<$1')
-    .replace (new RegExp('</('+blocks+')></p>', 'ig'), '</$1>');
-
-  elem.value = text;
-
-}


### PR DESCRIPTION
* Unifies use_local_css and use_local_javascript into use_local_assets
* Exposes delivery information to the javascript elements in the nodeinfojson
* Consolidates the autoformat javascript into the HTMLToolbar editor where it was the only thing that needed it
* Fixes a database standup issue exposed by the movement of the cron jobs over to the cron folder
* Fixes a few bugs where bad data types in DataStash elements would cause Server Errors, but didn't get all of them

Fixes #2866
Fixes #2867