### PR TITLE
Exposing the vitals preferences to Javascript to begin to port them o…

### DIFF
--- a/docker/e2app/apache2_wrapper.rb
+++ b/docker/e2app/apache2_wrapper.rb
@@ -25,6 +25,6 @@ if ENV['E2DOCKER'].nil? or !ENV['E2DOCKER'].eql? "development"
 end
 
 `rm -f /etc/apache2/logs/error_log`
-`ln -s /dev/stderr /etc/apache2/logs/error_log`
+`ln -s /dev/stderr /etc/apache2/logs/error_log` unless ENV['E2DOCKER'].eql? "development"
 
 exec("/usr/sbin/apachectl -D FOREGROUND")

--- a/ecore/Everything/API/preferences.pm
+++ b/ecore/Everything/API/preferences.pm
@@ -1,0 +1,86 @@
+
+package Everything::API::preferences;
+
+use Moose;
+use namespace::autoclean;
+extends 'Everything::API';
+
+## no critic (ProhibitBuiltinHomonyms)
+
+has 'allowed_preferences' => (isa => 'HashRef', is => 'ro', default => sub { {
+  'vit_hidemaint' => [0,1],
+  'vit_hidenodeinfo' => [0,1],
+  'vit_hideutil' => [0,1],
+  'vit_hidelist' => [0,1],
+  'vit_hidemisc' => [0,1]
+}});
+
+sub routes
+{
+  return {
+  "set" => "set_preferences",
+  "get" => "get_preferences",
+  }
+}
+
+sub set_preferences
+{
+  my ($self, $REQUEST) = @_;
+
+  my $data = $REQUEST->JSON_POSTDATA;
+
+  my $valid = 1;
+  if(ref $data ne "HASH" or scalar(keys %$data) == 0)
+  {
+    return [$self->HTTP_BAD_REQUEST];
+  }
+
+  foreach my $key (keys %$data)
+  {
+    unless(defined($self->allowed_preferences->{$key}) and scalar(grep({"$data->{$key}" eq "$_"} @{$self->allowed_preferences->{$key}})) == 1)
+    {
+      $valid = 0;
+    }
+  }
+
+  return [$self->HTTP_UNAUTHORIZED] if $valid == 0;
+
+  foreach my $key (keys %$data)
+  {
+    $REQUEST->user->VARS->{$key} = $data->{$key};
+  }
+  $REQUEST->user->set_vars($REQUEST->user->VARS);
+
+  return [$self->HTTP_OK, $self->current_preferences($REQUEST)];
+}
+
+sub get_preferences
+{
+  my ($self, $REQUEST) = @_;
+
+  return [$self->HTTP_OK, $self->current_preferences($REQUEST)];
+}
+
+sub current_preferences
+{
+  my ($self, $REQUEST) = @_;
+
+  my $vars = $REQUEST->user->VARS;
+
+  my $result = {};
+  foreach my $key (keys %{$self->allowed_preferences})
+  {
+    if(defined($vars->{$key}))
+    {
+      $result->{$key} = $vars->{$key};
+    }else{
+      $result->{$key} = 0;
+    }
+  }
+  return $result;
+}
+
+around ['set_preferences'] => \&Everything::API::unauthorized_if_guest;
+
+__PACKAGE__->meta->make_immutable;
+1;

--- a/ecore/Everything/APIClient.pm
+++ b/ecore/Everything/APIClient.pm
@@ -209,4 +209,16 @@ sub roompurge
   return $self->_format_response($self->ua->get($self->endpoint."/systemutilities/roompurge"));
 }
 
+sub get_preferences
+{
+  my ($self) = @_;
+  return $self->_format_response($self->ua->get($self->endpoint."/preferences/get"));
+}
+
+sub set_preferences
+{
+  my ($self, $data) = @_;
+  return $self->_format_response($self->_do_post($self->endpoint."/preferences/set",$data));
+}
+
 1;

--- a/ecore/Everything/Application.pm
+++ b/ecore/Everything/Application.pm
@@ -4477,4 +4477,21 @@ sub asset_uri
   }
 }
 
+sub display_preferences
+{
+  my ($this, $vars) = @_;
+
+  my $prefs = {};
+  foreach my $nodelet (qw(vit))
+  {
+    foreach my $var (qw(nodeinfo maintenance nodeutil list misc))
+    {
+      my $prefname = $nodelet."_hide$var";
+      $prefs->{$prefname} = $vars->{$nodelet."_hide$var"} || 0;
+    }
+  }
+
+  return $prefs;
+}
+
 1;

--- a/ecore/Everything/Controller.pm
+++ b/ecore/Everything/Controller.pm
@@ -86,6 +86,7 @@ sub layout
   $e2->{collapsedNodelets} =~ s/\bsignin\b//;
   $e2->{noquickvote} = 1 if($REQUEST->VARS->{noquickvote});
   $e2->{nonodeletcollapser} = 1 if($REQUEST->VARS->{nonodeletcollapser});
+  $e2->{displayprefs} = $self->APP->display_preferences($REQUEST->VARS);
   $params->{nodeinfojson} = $self->JSON->encode($e2);
 
   $params->{no_ads} = 1 unless($REQUEST->is_guest);

--- a/ecore/Everything/Delegation/htmlcode.pm
+++ b/ecore/Everything/Delegation/htmlcode.pm
@@ -4095,6 +4095,7 @@ sub static_javascript
   }else{
     $e2->{assets_location} = "";
   }
+  $e2->{display_prefs} = $APP->display_preferences($VARS);
   $e2 = encode_json($e2);
 
   my $libraries = qq'<script src="https://code.jquery.com/jquery-1.11.1.min.js" type="text/javascript"></script>';

--- a/ecore/Everything/Node/helper/setting.pm
+++ b/ecore/Everything/Node/helper/setting.pm
@@ -10,4 +10,10 @@ sub _build_VARS
   return $self->APP->getVars($self->NODEDATA); 
 }
 
+sub set_vars
+{
+  my ($self, $vars) = @_;
+  return Everything::setVars($self->NODEDATA, $vars);
+}
+
 1;

--- a/t/010_preferences.t
+++ b/t/010_preferences.t
@@ -1,0 +1,37 @@
+#!/usr/bin/perl -w
+
+use strict;
+use FindBin;
+use lib "$FindBin::Bin/../ecore";
+use Test::More;
+use Everything::APIClient;
+
+my $testpref = "vit_hidenodeinfo";
+my $testpref2 = "vit_hidemisc";
+
+ok(my $eapi = Everything::APIClient->new("endpoint" => "http://localhost:9080/api"), "Create new E2 API object");
+
+ok(my $guest_prefs = $eapi->get_preferences, "Get Guest Users Preferences");
+ok($guest_prefs->{code} == 200, "Guest get preferences comes back as 200 OK");
+ok((defined($guest_prefs->{data}->{$testpref}) and ($guest_prefs->{data}->{$testpref} == 0)), "Sample guest user preference is zero");
+ok(my $set_response = $eapi->set_preferences({$testpref => 1}), "Try to set a preference as guest");
+ok($set_response->{code} == 401, "Guest gets unauthorized");
+
+ok($eapi->login("normaluser1","blah"), "Log in as normaluser 1");
+ok($set_response = $eapi->set_preferences({$testpref => 1}), "Set a preference as normaluser1");
+ok($set_response->{code} == 200, "Normaluser1 set preferences comes back as 200 OK");
+ok($set_response->{data}->{$testpref} == 1, "Set worked correctly");
+
+ok(my $get_response = $eapi->get_preferences, "Get preferences to check to make sure the update stuck");
+ok($get_response->{code} == 200, "Normaluser1 get preferences comes back as 200 OK");
+ok($get_response->{data}->{$testpref} == 1, "Set was committed");
+ok($set_response = $eapi->set_preferences({"non_whitelisted_pref" => 1}), "Set a bad preference as normaluser1");
+ok($set_response->{code} == 401, "Comes back as unauthorized");
+ok($set_response = $eapi->set_preferences({$testpref => "badvalue"}), "Set a preference to a non-whitelisted value as normaluser1");
+ok($set_response->{code} == 401, "Comes back as unauthorized");
+
+ok($set_response = $eapi->set_preferences({$testpref => "badvalue", $testpref2 => 0}), "Setting mixed preferences");
+ok($set_response->{code} == 401, "Comes back as unauthorized");
+
+
+done_testing;

--- a/www/js/legacy.js
+++ b/www/js/legacy.js
@@ -3712,3 +3712,109 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 ga('create', 'UA-1314738-1', 'auto');
 ga('require', 'displayfeatures');
 ga('send', 'pageview');
+
+function link_node_title(link_to, title)
+{
+  if(title === undefined)
+  {
+    title = link_to;
+  }
+
+  return '<a href="/title/'+encodeURIComponent(link_to)+'">'+unescapeHTML(title)+'</a>';
+}
+
+// Vitals nodelet
+var vitals_links = [
+  ["Maintenance","maint",[
+    ["Node Title Edit","Edit These E2 Titles"],
+    ["Broken Writeups","Broken Nodes"],
+    ["Writeup Deletion Request","E2 Nuke Request"],
+    ["Make a bug report","E2 Bugs"],
+    ["Suggest a change to E2","Suggestions for E2"]]
+  ],
+  ["Noding Information","nodeinfo",[
+    ["E2 HTML Tags"],
+    ["HTML Symbol Reference"],
+    ["Using Unicode on E2"],
+    ["Reference Desk"]]
+  ],
+  ["Noding Utilities","nodeutil",[
+    ["Node Tracker"],
+    ["Source Code Formatter","E2 Source Code Formatter"],
+    ["Text Formatter"]]
+  ],
+  ["Lists","list",[
+    ["Writeups By Type"],
+    ["Everything's Most Wanted"],
+    ["C! writeups","Cool Archive"],
+    ["Editor Picks","Page of Cool"],
+    ["Usergroup Picks"],
+    ["A Year Ago Today"],
+    ["Old News","News for Noders. Stuff that Matters"],
+    ["Your nodeshells"],
+    ["Random nodeshells"]]
+  ],
+  ["Miscellaneous","misc",[
+    ["Everything User Poll"],
+    ["The Everything2 Voting/Experience System"],
+    ["Chatterlight"],
+    ["E2 Gift Shop"],
+    ["Everything Quote Server"],
+    ["The Registries"],
+    ["Do you C! what I C?"],
+    ["The Recommender"]
+  ]]
+];
+
+function is_section_open(sectionname,sectionid)
+{
+  return e2.display_prefs[sectionname+"_hide"+sectionid] == 0;
+}
+
+function toggle_section(sectionname, sectionid)
+{
+  if(is_section_open(sectionname, sectionid))
+  {
+    e2.display_prefs[sectionname+"_hide"+sectionid] = 0;
+//    $("#"+sectionname+"section_"+sectionid).removeClass("slide-down");
+    $("#"+sectionname+"section_"+sectionid).addClass("slide-up");
+  }else{
+    e2.display_prefs[sectionname+"_hide"+sectionid] = 1;
+//    $("#"+sectionname+"section_"+sectionid).removeClass("slide-up");
+    $("#"+sectionname+"section_"+sectionid).addClass("slide-down");
+  }
+}
+
+
+$("#vitalstest").html(function(){
+  heading = $('<h2 />', {class: "nodelet_title open ui-sortable-handle", style: "cursor: pointer;", text: "Vitals"});
+  heading.append("<style> \n.slider.sliderclosed { max-height: 0; } .slider { overflow-y: hidden; max-height: 100%; transition-property: all; transition-duration: .5s; transition-timing-function: cubic-bezier(0, 1, 0.5, 1); } </style>");
+
+  container = $('<div />',{class: "nodelet_content"});
+  vitals_links.forEach(function(section, section_index) {
+    section_name = section[1];
+    nodeletsection = $('<div />', {class: "nodeletsection", id: "vitsection_"+section_name});
+
+    open_link = $('<a />', {href: "#", text: "+"});
+    if(e2.display_prefs["vit_hide"+section_name] == 1)
+    {
+      open_link = $('<a />', {href: "#", text: "-"});
+    }
+    nodeletsection.append('<div class="sectionheading"><tt>[ '+open_link.prop("outerHTML")+' ] </tt>'+$('<strong />',{text: section[0]}).prop("outerHTML")+'</div>');
+    section_content = $('<div />',{class: "sectioncontent"});
+    links_list = $('<ul />');
+    section[2].forEach(function(link,link_index) {
+      link_href = link[1];
+      if(link_href === undefined)
+      {
+        link_href = link[0];
+      }
+      anchor = $('<a />', {title: link[0], href: "/node/"+encodeURIComponent(link_href), class: "populated", text: link[0]});
+      links_list.append('<li>'+anchor.prop("outerHTML")+'</li>');
+    });
+    section_content.append(links_list.prop("outerHTML"));
+    nodeletsection.append(section_content.prop("outerHTML"));
+    container.append(nodeletsection.prop("outerHTML"));
+  });
+  return heading.prop("outerHTML")+container.prop("outerHTML");
+});


### PR DESCRIPTION
…ver to React

Also adds a preferences API for future use
Adds a failed-ish port of the Vitals nodelet to jquery, but further investigation suggests that we can just go straight to React now.

Fixes #2953