### PR TITLE
Fixes backtick hostname call in Master Control

### DIFF
--- a/ecore/Everything/Configuration.pm
+++ b/ecore/Everything/Configuration.pm
@@ -8,6 +8,7 @@ use LWP::UserAgent;
 use JSON;
 use namespace::autoclean;
 use Config;
+use Sys::Hostname;
 
 has 'configfile' => (isa => 'Maybe[Str]', is => 'ro');
 has 'configdir' => (isa => 'Str', is => 'ro', default => '/etc/everything');
@@ -220,6 +221,8 @@ has 'room_cleanup_threshold' => (isa => 'Int', is => 'ro', default => 60*60*24*9
 has 'always_keep_rooms' => (isa => 'ArrayRef[Str]', is => 'ro', default => sub {["Valhalla", "Political Asylum", "M-Noder Washroom", "Noders Nursery", "Debriefing Room"]});
 
 has 'architecture' => (isa => 'Str', is => 'ro', builder => '_build_architecture');
+
+has 'server_hostname' => (isa => 'Str', is => 'ro', builder => '_build_server_hostname', lazy => 1);
 
 around BUILDARGS => sub
 {
@@ -440,6 +443,14 @@ sub _build_architecture
   my $arch = $Config{archname};
   $arch =~ s/-.*//g;
   return $arch;
+}
+
+sub _build_server_hostname
+{
+  my ($self) = @_;
+  my $hostname = Sys::Hostname::hostname;
+  $hostname =~ s/\..*//;
+  return $hostname;
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/ecore/Everything/Delegation/htmlcode.pm
+++ b/ecore/Everything/Delegation/htmlcode.pm
@@ -135,9 +135,7 @@ sub admin_searchform
   my $nid = getId($NODE) || '';
   return unless $APP->isEditor($USER); 
 
-  my $servername = `hostname`;
-  chomp $servername;
-  $servername =~ s/\..*//g;
+  my $servername = $Everything::CONF->server_hostname;
   my $str = "<span class='var_label'>node_id:</span> <span class='var_value'>$nid</span>
 			<span class='var_label'>nodetype:</span> <span class='var_value'>".linkNode($$NODE{type})."</span>
 			<span class='var_label'>Server:</span> <span class='var_value'>$servername</span>";


### PR DESCRIPTION
This was pretty high on Devel::Nytprof's list

Fixes #3282