### PR TITLE
CSS-only modification

### DIFF
--- a/tools/seeds.pl
+++ b/tools/seeds.pl
@@ -1166,6 +1166,35 @@ if (!$amp_in_group) {
 $DB->updateNode($amp_writeup, -1);
 print STDERR "Ampersand test fixture (#4060): '$amp_writeup->{title}'\n";
 
+# Multi-space e2node fixture -- #3418 (titles with consecutive spaces).
+# The title intentionally has two spaces after the period so we can verify the
+# basesheet's `white-space: pre-wrap` rule keeps the runs intact through DOM
+# copy. Without that rule, browsers collapse the run on render and the
+# clipboard gets the single-space form, which won't match the actual title.
+my $multispace_title = "I was raised on red pepper and blood.  I am so hot if you strike me I will light like a match.";
+my $ms_e2node = $DB->getNode($multispace_title, "e2node");
+if (!$ms_e2node) {
+  my $ms_e2node_id = $DB->insertNode($multispace_title, "e2node", $root);
+  $ms_e2node = $DB->getNodeById($ms_e2node_id);
+}
+my $ms_writeup_title = "$multispace_title (thing)";
+my $ms_writeup = $DB->getNode($ms_writeup_title, "writeup");
+if (!$ms_writeup) {
+  my $ms_writeup_id = $DB->insertNode($ms_writeup_title, "writeup", $normaluser1);
+  $ms_writeup = $DB->getNodeById($ms_writeup_id);
+}
+$ms_writeup->{parent_e2node} = $ms_e2node->{node_id};
+$ms_writeup->{wrtype_writeuptype} = $thing_writeuptype->{node_id};
+$ms_writeup->{doctext} = "A short body so the e2node renders as a normal node and not a nodeshell.";
+$ms_writeup->{publishtime} = $ms_writeup->{createtime};
+my $ms_in_group = $DB->sqlSelect('COUNT(*)', 'nodegroup',
+  "nodegroup_id=$ms_e2node->{node_id} AND node_id=$ms_writeup->{node_id}");
+if (!$ms_in_group) {
+  $DB->insertIntoNodegroup($ms_e2node, -1, $ms_writeup);
+}
+$DB->updateNode($ms_writeup, -1);
+print STDERR "Multi-space test fixture (#3418): '$ms_e2node->{title}'\n";
+
 # C! assignments - normaluser1-20 all cool "good poetry" to test tooltip with many C!s
 my $cools = {
   "normaluser1" => ["good poetry (poetry)", "swedish tomatoë (essay)"],

--- a/www/css/1973976.css
+++ b/www/css/1973976.css
@@ -584,6 +584,22 @@ p#printlink {
   font-size: 107%;
 }
 
+/* #3418: Preserve consecutive whitespace in node titles so copy-paste into
+   the search box round-trips. Default `white-space: normal` collapses
+   `"foo.  bar"` to `"foo. bar"` when the browser renders text, and the copy
+   operation grabs the collapsed form — so titles with multiple spaces become
+   un-searchable. `pre-wrap` keeps the runs intact while still wrapping at
+   word boundaries. Scoped narrowly to elements whose text content is a node
+   title the user is likely to copy. */
+.nodetitle,
+.page-header__title,
+h1.nodetitle,
+.contentinfo a.title,
+.findings-item > a,
+.infolist a {
+  white-space: pre-wrap;
+}
+
 .contentinfo a {
   text-decoration: none;
 }


### PR DESCRIPTION
Copy and paste of titles is no longer suppressed by CSS rules

Fixes #3418